### PR TITLE
convert tabs to spaces in layout

### DIFF
--- a/views/layout.pug
+++ b/views/layout.pug
@@ -18,5 +18,5 @@ html
         p &copy; The Retail Apocalypse
 
     block scripts
-			script(src=`https://maps.googleapis.com/maps/api/js?key=${process.env.MAP_KEY}&libraries=places`)
+      script(src=`https://maps.googleapis.com/maps/api/js?key=${process.env.MAP_KEY}&libraries=places`)
       script(src="/dist/App.bundle.js")


### PR DESCRIPTION
Tabs and spaces cause problems in pub because indentation is so important to pug structure. Both Atom and Sublime (and all modern text editors) have a convert tabs to spaces (In sublime text I use cmd + shift + p and then select (Indentation: Convert to spaces) and that fixed the error